### PR TITLE
fix PyBullet rendering slow-down

### DIFF
--- a/rendering/pybullet_rendering.py
+++ b/rendering/pybullet_rendering.py
@@ -10,8 +10,26 @@ import pybullet_data
 
 SAVE_IMG_AND_EXIT = False
 
-pybullet.connect(pybullet.GUI)
-# pybullet.connect(pybullet.DIRECT)
+if 0:
+    pybullet.connect(pybullet.GUI)
+else:
+    #headless, works in the cloud, Google Colab
+    import pkgutil
+    egl = pkgutil.get_loader('eglRenderer')
+
+    pybullet.connect(pybullet.DIRECT)
+    pybullet.setAdditionalSearchPath(pybullet_data.getDataPath())
+    plugin = pybullet.loadPlugin(egl.get_filename(), "_eglRendererPlugin")
+    print("plugin=", plugin)
+
+if 1:
+  pybullet.configureDebugVisualizer(pybullet.COV_ENABLE_SEGMENTATION_MARK_PREVIEW,0)
+  pybullet.configureDebugVisualizer(pybullet.COV_ENABLE_RGB_BUFFER_PREVIEW,0)
+  pybullet.configureDebugVisualizer(pybullet.COV_ENABLE_DEPTH_BUFFER_PREVIEW,0)
+  pybullet.configureDebugVisualizer(pybullet.COV_ENABLE_RENDERING,0)
+  pybullet.configureDebugVisualizer(pybullet.COV_ENABLE_GUI, 0)
+
+
 
 pybullet.setAdditionalSearchPath(pybullet_data.getDataPath())
 pybullet.loadURDF("plane.urdf", [0, 0, 0])


### PR DESCRIPTION
Nice work on the benchmark, just noticed this today. Here are some fixes in the pybullet_rendering.py script, timings on a RTX 3090 should be around 250 FPS for the OpenGL renderer., not 29.4 (that hints on Sync-to-VBlank).

A few notes:
*  Please make sure that nvidia-settings OpenGL Settings, Sync-to-VBlank is off (see attached image). Updated script disables the GUI so it will work independent from Sync-to-VBlank setting.
*  Updated script can also run optionally headless using EGL, in a Google Colab for example
*  Please ignore/remove TinyRenderer in the timings, it is too slow for a benchmark. It is for machines that have no proper GPU installed.

Here are my timings on a 3090 RTX GPU, on Ubuntu 22.04, Intel i7:

```
renderImage 0.003683
renderImage 0.003261
Total time 0.389455
Mean render time:  0.0038753199577331544
frequency:  258.04320956893173
```
The citations are here: https://scholar.google.com/scholar?hl=en&as_sdt=0,5&cluster=14155418983690238411
PyBullet is cited by 1942 as of this pull request

Could you please update the table in https://simulately.wiki/docs/comparison with new timings and citations?

![image](https://github.com/user-attachments/assets/c511029b-bd0d-41ff-87ed-76ca8eccfece)
